### PR TITLE
Update to bs-platform ^4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
         "jszip": "^3.1.5"
     },
     "devDependencies": {
-        "bs-platform": "^2.2.3"
+        "bs-platform": "^4.0.6"
+    },
+    "scripts": {
+      "build": "bsb -make-world",
+      "clean": "bsb -clean-world",
+      "watch": "bsb -make-world -w"
     }
 }

--- a/src/blob.re
+++ b/src/blob.re
@@ -11,7 +11,7 @@ type endings = [ | `native | `transparent];
 external createAux : (array('a), ~options: blobOptions=?, unit) => blob =
   "Blob";
 
-[@bs.send] external isClosed : blob => Js.boolean = "isClosed";
+[@bs.send] external isClosed : blob => bool = "isClosed";
 
 [@bs.send] external size : blob => int = "size";
 

--- a/src/blob.rei
+++ b/src/blob.rei
@@ -9,7 +9,7 @@ let create: (~options: blobOptions=?, array('a)) => t;
 let makeOptions:
   (~type_: Mime.types=?, ~endings: endings=?, unit) => blobOptions;
 
-let isClosed: t => Js.boolean;
+let isClosed: t => bool;
 
 let size: t => int;
 

--- a/src/converters.re
+++ b/src/converters.re
@@ -9,9 +9,6 @@ type metadata = {
  */
 let makeJsOptionMap = (f, b) => Js.Option.map((. a) => f(a), b);
 
-/* For boolean props */
-let fromBool = makeJsOptionMap(Js.Boolean.to_js_boolean);
-
 let dateFromString = makeJsOptionMap(Js.Date.fromString);
 
 [@bs.deriving jsConverter]

--- a/src/options.re
+++ b/src/options.re
@@ -14,26 +14,26 @@ type asyncUint8Options;
 
 /* Utilities to build the options */
 [@bs.obj]
-external makeWriteOptionsAux :
+external makeWriteOptionsAux:
   (
-    ~base64: Js.boolean=?,
-    ~binary: Js.boolean=?,
+    ~base64: bool=?,
+    ~binary: bool=?,
     ~date: Js.Date.t=?,
     ~compression: string=?,
     ~compressionOptions: cOptions=?,
     ~comment: string=?,
-    ~optimizedBinaryString: Js.boolean=?,
-    ~createFolders: Js.boolean=?,
+    ~optimizedBinaryString: bool=?,
+    ~createFolders: bool=?,
     ~unixPermissions: int=?,
     ~dosPermissions: int=?,
-    ~dir: Js.boolean=?,
+    ~dir: bool=?,
     unit
   ) =>
   wOptions =
   "";
 
 [@bs.obj]
-external makeCompressionOptionsAux : (~level: int=?, unit) => cOptions = "";
+external makeCompressionOptionsAux: (~level: int=?, unit) => cOptions = "";
 
 let makeWriteOptions =
     (
@@ -51,24 +51,24 @@ let makeWriteOptions =
       (),
     ) =>
   makeWriteOptionsAux(
-    ~base64=?fromBool(base64),
-    ~binary=?fromBool(binary),
+    ~base64?,
+    ~binary?,
     ~date=?dateFromString(date),
     ~compression=?fromCompression(compression),
     ~compressionOptions?,
     ~comment?,
-    ~optimizedBinaryString=?fromBool(optimizedBinaryString),
-    ~createFolders=?fromBool(createFolders),
+    ~optimizedBinaryString?,
+    ~createFolders?,
     ~unixPermissions?,
     ~dosPermissions?,
-    ~dir=?fromBool(dir),
+    ~dir?,
     (),
   );
 
 let makeCompressionOptions = lvl => makeCompressionOptionsAux(~level=lvl, ());
 
 [@bs.obj]
-external makeAsyncBlobOptionsAux :
+external makeAsyncBlobOptionsAux:
   (
     ~_type: [@bs.as "blob"] _,
     ~compression: string=?,
@@ -77,15 +77,15 @@ external makeAsyncBlobOptionsAux :
     ~mimeType: string=?,
     ~platform: string=?,
     ~encodeFileName: string => Js.Typed_array.Uint8Array.t=?,
-    ~streamFiles: Js.boolean=?,
-    ~createFolders: Js.boolean=?,
+    ~streamFiles: bool=?,
+    ~createFolders: bool=?,
     unit
   ) =>
   asyncBlobOptions =
   "";
 
 [@bs.obj]
-external makeAsyncStringOptionsAux :
+external makeAsyncStringOptionsAux:
   (
     ~_type: [@bs.as "uint8array"] _,
     ~compression: string=?,
@@ -94,15 +94,15 @@ external makeAsyncStringOptionsAux :
     ~mimeType: string=?,
     ~platform: string=?,
     ~encodeFileName: string => Js.Typed_array.Uint8Array.t=?,
-    ~streamFiles: Js.boolean=?,
-    ~createFolders: Js.boolean=?,
+    ~streamFiles: bool=?,
+    ~createFolders: bool=?,
     unit
   ) =>
   asyncStringOptions =
   "";
 
 [@bs.obj]
-external makeAsyncUint8OptionsAux :
+external makeAsyncUint8OptionsAux:
   (
     ~_type: [@bs.as "uint8array"] _,
     ~compression: string=?,
@@ -111,8 +111,8 @@ external makeAsyncUint8OptionsAux :
     ~mimeType: string=?,
     ~platform: string=?,
     ~encodeFileName: string => Js.Typed_array.Uint8Array.t=?,
-    ~streamFiles: Js.boolean=?,
-    ~createFolders: Js.boolean=?,
+    ~streamFiles: bool=?,
+    ~createFolders: bool=?,
     unit
   ) =>
   asyncUint8Options =
@@ -138,8 +138,8 @@ let makeAsyncBlobOptions =
     ~mimeType=?fromMimeTypes(mimeType),
     ~platform=?fromPlatforms(platform),
     ~encodeFileName?,
-    ~streamFiles=?fromBool(streamFiles),
-    ~createFolders=?fromBool(createFolders),
+    ~streamFiles?,
+    ~createFolders?,
     (),
   );
 
@@ -163,8 +163,8 @@ let makeAsyncStringOptions =
     ~mimeType=?fromMimeTypes(mimeType),
     ~platform=?fromPlatforms(platform),
     ~encodeFileName?,
-    ~streamFiles=?fromBool(streamFiles),
-    ~createFolders=?fromBool(createFolders),
+    ~streamFiles?,
+    ~createFolders?,
     (),
   );
 
@@ -188,18 +188,18 @@ let makeAsyncUint8Options =
     ~mimeType=?fromMimeTypes(mimeType),
     ~platform=?fromPlatforms(platform),
     ~encodeFileName?,
-    ~streamFiles=?fromBool(streamFiles),
-    ~createFolders=?fromBool(createFolders),
+    ~streamFiles?,
+    ~createFolders?,
     (),
   );
 
 [@bs.obj]
-external makeLoadOptionsAux :
+external makeLoadOptionsAux:
   (
-    ~base64: Js.boolean=?,
-    ~checkCRC32: Js.boolean=?,
-    ~optimizedBinaryString: Js.boolean=?,
-    ~createFolders: Js.boolean=?,
+    ~base64: bool=?,
+    ~checkCRC32: bool=?,
+    ~optimizedBinaryString: bool=?,
+    ~createFolders: bool=?,
     ~decodeFileName: Js.Typed_array.Uint8Array.t => string=?,
     unit
   ) =>
@@ -216,10 +216,10 @@ let makeLoadOptions =
       (),
     ) =>
   makeLoadOptionsAux(
-    ~base64=?fromBool(base64),
-    ~checkCRC32=?fromBool(checkCRC32),
-    ~optimizedBinaryString=?fromBool(optimizedBinaryString),
-    ~createFolders=?fromBool(createFolders),
+    ~base64?,
+    ~checkCRC32?,
+    ~optimizedBinaryString?,
+    ~createFolders?,
     ~decodeFileName?,
     (),
   );

--- a/src/zip.re
+++ b/src/zip.re
@@ -10,11 +10,11 @@ external create : unit => jszip = "jszip";
 [@bs.val] [@bs.module "jszip"]
 external support : {
   .
-  "arraybuffer": Js.boolean,
-  "uint8array": Js.boolean,
-  "blob": Js.boolean,
-  "nodebuffer": Js.boolean,
-  "nodestream": Js.boolean,
+  "arraybuffer": bool,
+  "uint8array": bool,
+  "blob": bool,
+  "nodebuffer": bool,
+  "nodestream": bool,
 } =
   "support";
 

--- a/src/zip.rei
+++ b/src/zip.rei
@@ -20,11 +20,11 @@ type jszip;
  */
 let support: {
   .
-  "arraybuffer": Js.boolean,
-  "uint8array": Js.boolean,
-  "blob": Js.boolean,
-  "nodebuffer": Js.boolean,
-  "nodestream": Js.boolean,
+  "arraybuffer": bool,
+  "uint8array": bool,
+  "blob": bool,
+  "nodebuffer": bool,
+  "nodestream": bool,
 };
 
 /**

--- a/src/zipObject.re
+++ b/src/zipObject.re
@@ -1,7 +1,7 @@
 type t = {
   .
   "name": string,
-  "dir": Js.boolean,
+  "dir": bool,
   "date": Js.Date.t,
   "comment": string,
   "unixPermissions": int,

--- a/src/zipObject.rei
+++ b/src/zipObject.rei
@@ -1,7 +1,7 @@
 type t = {
   .
   "name": string,
-  "dir": Js.boolean,
+  "dir": bool,
   "date": Js.Date.t,
   "comment": string,
   "unixPermissions": int,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-bs-platform@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+bs-platform@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.6.tgz#e7f156c77ad3efafb0c0291b41dcf1b06f93c192"
 
 core-js@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This updates the library to bs-platform ^4.0.6.

Summary of changes:
  - switched `Js.boolean` to `bool`
  - removed `Js.boolean` helper functions
  - added scripts to run bsb commands